### PR TITLE
Add WandB sweep utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,24 @@ python main.py
 The script loads data from the `data/` directory, trains a logistic regression
 model and prints the return on investment for a basic betting strategy.
 
+## W&B Sweeps
+
+Hyperparameter sweeps can be launched directly from the package:
+
+```bash
+python -m nfl_bet.wandb_train sweep
+```
+
+The sweep configuration mirrors the notebook setup. The following options can
+be customised via command line flags or environment variables:
+
+- `--project` / `WANDB_SWEEP_PROJECT` – W&B project name (default
+  `nfl_bet_sweep`)
+- `--count` / `WANDB_SWEEP_COUNT` – number of runs to execute (default `1`)
+
+Example:
+
+```bash
+WANDB_SWEEP_PROJECT=my_proj python -m nfl_bet.wandb_train sweep --count 10
+```
+


### PR DESCRIPTION
## Summary
- implement `create_sweep` and `run_sweep` helpers using the configuration from the notebook
- add CLI `python -m nfl_bet.wandb_train sweep` to create and start sweeps
- document sweep usage and env vars in README

## Testing
- `python -m py_compile nfl_bet/wandb_train.py`
- `python -m nfl_bet.wandb_train --help | head -n 20`
- `python -m nfl_bet.wandb_train sweep --help | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6841bffb5fe8832ca4a0755624687cda