### PR TITLE
Fix duplicate metrics in sweeps

### DIFF
--- a/nfl_bet.py
+++ b/nfl_bet.py
@@ -881,8 +881,6 @@ def create_sweep():
 
   return sweep_id
 
-precision_metric = tf.keras.metrics.Precision()
-recall_metric = tf.keras.metrics.Recall()
 
 def evaluate_and_log_metrics(model, X, y, tag):
     # Evaluate the model on the provided data
@@ -940,6 +938,10 @@ def train(config=None):
                 ('cat', OneHotEncoder(), categorical_features)
             ]
         )
+
+        # Fresh metric instances for each run to avoid duplicate logging
+        precision_metric = tf.keras.metrics.Precision()
+        recall_metric = tf.keras.metrics.Recall()
 
         # Generate or define a random seed
         random_state = random.randint(0, 1_000)

--- a/nfl_bet/wandb_train.py
+++ b/nfl_bet/wandb_train.py
@@ -84,11 +84,6 @@ binary_features = ["div_game"]
 non_numerical_features = categorical_features + binary_features
 numerical_features = [f for f in features if f not in non_numerical_features]
 
-
-precision_metric = tf.keras.metrics.Precision()
-recall_metric = tf.keras.metrics.Recall()
-
-
 def get_activation(name: str):
     if name == "elu":
         return tf.keras.activations.elu
@@ -167,6 +162,10 @@ def train(config: Optional[dict] = None) -> None:
                 ("cat", OneHotEncoder(), categorical_features),
             ]
         )
+
+        # Fresh metric instances for each run to avoid duplicate logging
+        precision_metric = tf.keras.metrics.Precision()
+        recall_metric = tf.keras.metrics.Recall()
 
         random_state = random.randint(0, 1000)
         wandb.log({"random_state": random_state})


### PR DESCRIPTION
## Summary
- avoid global Keras metrics in sweep utilities
- instantiate fresh metrics for every training run

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841d0df3070832c8c2b9bb68c77f0f1