### PR TITLE
Parameterize wandb entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,7 @@ This project is designed to predict NFL game outcomes and to evaluate associated
 
 * **Artifact Management**:
     * Leverages `wandb` for logging, versioning, and retrieving critical artifacts such as preprocessing pipelines and trained machine learning models, ensuring reproducibility and traceability.
+
+## W&B Usage
+
+Evaluation and training utilities use Weights & Biases for experiment tracking. If your runs live under a specific W&B entity (organization or username), set the `WANDB_ENTITY` environment variable so the scripts can locate artifacts and runs across accounts.


### PR DESCRIPTION
## Summary
- allow specifying W&B entity via `WANDB_ENTITY`
- add optional `entity` arg to wandb evaluation helpers
- update archived evaluation script for same behaviour
- document `WANDB_ENTITY` env variable

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684206034128832c8f3c322ca2e45009