### PR TITLE
Generalize bet helpers

### DIFF
--- a/nfl_bet/betting.py
+++ b/nfl_bet/betting.py
@@ -8,52 +8,111 @@ def implied_probability(moneyline: float) -> float:
     return -moneyline / (-moneyline + 100)
 
 
-def calculate_implied_probabilities(df: pd.DataFrame, fav_col: str = "fav_moneyline", dog_col: str = "dog_moneyline") -> pd.DataFrame:
+def calculate_implied_probabilities(
+    df: pd.DataFrame,
+    *,
+    team1_odds_col: str,
+    team2_odds_col: str,
+    team1_label: str = "dog",
+    team2_label: str = "fav",
+) -> pd.DataFrame:
+    """Add implied probability columns for the provided odds columns."""
     df = df.copy()
-    df["fav_implied_prob"] = df[fav_col].apply(implied_probability)
-    df["dog_implied_prob"] = df[dog_col].apply(implied_probability)
+    df[f"{team1_label}_implied_prob"] = df[team1_odds_col].apply(implied_probability)
+    df[f"{team2_label}_implied_prob"] = df[team2_odds_col].apply(implied_probability)
     return df
 
 
-def determine_bet_team(row: pd.Series, margin: float = 0.0) -> str:
-    if row["predictions"] > (row["dog_implied_prob"] + margin):
-        return "dog"
-    if (1 - row["predictions"]) > (row["fav_implied_prob"] + margin):
-        return "fav"
+def determine_bet_team(
+    row: pd.Series,
+    *,
+    margin: float = 0.0,
+    team1_label: str = "dog",
+    team2_label: str = "fav",
+    team1_prob_col: str,
+    team2_prob_col: str,
+) -> str:
+    """Return which side to bet based on predictions and implied probabilities."""
+    if row["predictions"] > (row[team1_prob_col] + margin):
+        return team1_label
+    if (1 - row["predictions"]) > (row[team2_prob_col] + margin):
+        return team2_label
     return "none"
 
 
-def simple_bet_team(row: pd.Series) -> str:
-    return "dog" if row["predictions"] > 0.5 else "fav"
+def simple_bet_team(
+    row: pd.Series, *, team1_label: str = "dog", team2_label: str = "fav"
+) -> str:
+    """Bet on the side with the higher predicted probability."""
+    return team1_label if row["predictions"] > 0.5 else team2_label
 
 
-def calculate_stake(row: pd.Series, bet_amount: float, bet_strat: str = "both") -> float:
+def calculate_stake(
+    row: pd.Series,
+    bet_amount: float,
+    bet_strat: str = "both",
+    *,
+    team1_label: str = "dog",
+    team2_label: str = "fav",
+) -> float:
+    """Return the stake amount for a given strategy."""
     should_bet = False
     if bet_strat == "both":
         should_bet = row["bet_team"] != "none"
-    elif bet_strat == "dog":
-        should_bet = row["bet_team"] == "dog"
-    elif bet_strat == "fav":
-        should_bet = row["bet_team"] == "fav"
+    elif bet_strat == team1_label:
+        should_bet = row["bet_team"] == team1_label
+    elif bet_strat == team2_label:
+        should_bet = row["bet_team"] == team2_label
     return bet_amount if should_bet else 0.0
 
 
-def calculate_profit(row: pd.Series) -> float:
-    if row["bet_team"] == "fav":
-        if row["dog_win"] == 0:
-            return row["bet"] * (100 / -row["fav_moneyline"] if row["fav_moneyline"] < 0 else row["fav_moneyline"] / 100)
+def calculate_profit(
+    row: pd.Series,
+    *,
+    team1_label: str = "dog",
+    team2_label: str = "fav",
+    team1_odds_col: str,
+    team2_odds_col: str,
+    outcome_col: str,
+) -> float:
+    """Compute profit for a single game based on the bet outcome."""
+    if row["bet_team"] == team2_label:
+        if row[outcome_col] == 0:
+            odds = row[team2_odds_col]
+            return row["bet"] * (100 / -odds if odds < 0 else odds / 100)
         return -row["bet"]
-    if row["bet_team"] == "dog":
-        if row["dog_win"] == 1:
-            return row["bet"] * (100 / -row["dog_moneyline"] if row["dog_moneyline"] < 0 else row["dog_moneyline"] / 100)
+    if row["bet_team"] == team1_label:
+        if row[outcome_col] == 1:
+            odds = row[team1_odds_col]
+            return row["bet"] * (100 / -odds if odds < 0 else odds / 100)
         return -row["bet"]
     return 0.0
 
 
-def calculate_dog_fav_profits(df: pd.DataFrame, bet_amount: float = 100) -> pd.DataFrame:
+def calculate_fixed_side_profits(
+    df: pd.DataFrame,
+    *,
+    team1_odds_col: str,
+    team2_odds_col: str,
+    outcome_col: str,
+    team1_label: str = "dog",
+    team2_label: str = "fav",
+    bet_amount: float = 100,
+) -> pd.DataFrame:
+    """Compute profits if always betting on a given side."""
     df = df.copy()
-    df["dog_profit"] = df.apply(lambda r: bet_amount * (r["dog_moneyline"] / 100) if r["dog_win"] == 1 else -bet_amount, axis=1)
-    df["fav_profit"] = df.apply(lambda r: bet_amount * (100 / abs(r["fav_moneyline"])) if r["dog_win"] == 0 else -bet_amount, axis=1)
+    df[f"{team1_label}_profit"] = df.apply(
+        lambda r: bet_amount * (r[team1_odds_col] / 100)
+        if r[outcome_col] == 1
+        else -bet_amount,
+        axis=1,
+    )
+    df[f"{team2_label}_profit"] = df.apply(
+        lambda r: bet_amount * (100 / abs(r[team2_odds_col]))
+        if r[outcome_col] == 0
+        else -bet_amount,
+        axis=1,
+    )
     return df
 
 
@@ -62,8 +121,13 @@ def evaluate_betting_strategy(
     model,
     features,
     pipeline,
+    *,
     bet_amount: float = 100,
     target: str = "dog_win",
+    team1_label: str = "dog",
+    team2_label: str = "fav",
+    team1_odds_col: str = "dog_moneyline",
+    team2_odds_col: str = "fav_moneyline",
     use_implied_prob: bool = True,
     bet_strat: str = "both",
     margin: float = 0.0,
@@ -76,23 +140,66 @@ def evaluate_betting_strategy(
         predictions = model.predict(X_norm)
     df_eval = df.copy()
     df_eval["predictions"] = predictions
-    df_eval = calculate_implied_probabilities(df_eval)
+    df_eval = calculate_implied_probabilities(
+        df_eval,
+        team1_odds_col=team1_odds_col,
+        team2_odds_col=team2_odds_col,
+        team1_label=team1_label,
+        team2_label=team2_label,
+    )
     if use_implied_prob:
-        df_eval["bet_team"] = df_eval.apply(determine_bet_team, margin=margin, axis=1)
+        df_eval["bet_team"] = df_eval.apply(
+            determine_bet_team,
+            margin=margin,
+            team1_label=team1_label,
+            team2_label=team2_label,
+            team1_prob_col=f"{team1_label}_implied_prob",
+            team2_prob_col=f"{team2_label}_implied_prob",
+            axis=1,
+        )
     else:
-        df_eval["bet_team"] = df_eval.apply(simple_bet_team, axis=1)
-    df_eval["bet"] = df_eval.apply(lambda r: calculate_stake(r, bet_amount, bet_strat), axis=1)
-    df_eval["profit"] = df_eval.apply(calculate_profit, axis=1)
+        df_eval["bet_team"] = df_eval.apply(
+            simple_bet_team, team1_label=team1_label, team2_label=team2_label, axis=1
+        )
+    df_eval["bet"] = df_eval.apply(
+        lambda r: calculate_stake(
+            r,
+            bet_amount,
+            bet_strat,
+            team1_label=team1_label,
+            team2_label=team2_label,
+        ),
+        axis=1,
+    )
+    df_eval["profit"] = df_eval.apply(
+        calculate_profit,
+        team1_label=team1_label,
+        team2_label=team2_label,
+        team1_odds_col=team1_odds_col,
+        team2_odds_col=team2_odds_col,
+        outcome_col=target,
+        axis=1,
+    )
     total_profit = df_eval["profit"].sum()
     total_bet = df_eval["bet"].sum()
     roi = (total_profit / total_bet * 100) if total_bet else 0.0
-    df_eval = calculate_dog_fav_profits(df_eval, bet_amount=bet_amount)
-    dog_win_rate = df_eval[df_eval[target] == 1].shape[0] / len(df_eval) if len(df_eval) else 0.0
+    df_eval = calculate_fixed_side_profits(
+        df_eval,
+        team1_odds_col=team1_odds_col,
+        team2_odds_col=team2_odds_col,
+        outcome_col=target,
+        team1_label=team1_label,
+        team2_label=team2_label,
+        bet_amount=bet_amount,
+    )
+    win_rate = (
+        df_eval[df_eval[target] == 1].shape[0] / len(df_eval) if len(df_eval) else 0.0
+    )
     return {
         "total_profit": total_profit,
         "total_bet": total_bet,
         "roi": roi,
-        "dog_win_rate": dog_win_rate,
+        "win_rate": win_rate,
         "df": df_eval,
         "bet_rate": 100 * len(df_eval[df_eval["bet"] > 0]) / len(df_eval),
     }


### PR DESCRIPTION
## Summary
- expand betting functions to support custom bet labels and odds columns

## Testing
- `pytest -q`
- `python -m py_compile nfl_bet/betting.py`

------
https://chatgpt.com/codex/tasks/task_e_68432d2db128832ca32d73a8d6fda136