### PR TITLE
Add orientation and bet type options

### DIFF
--- a/nfl_bet/__init__.py
+++ b/nfl_bet/__init__.py
@@ -1,5 +1,9 @@
 from .data_prep import prepare_df
-from .betting import evaluate_betting_strategy, implied_probability
+from .betting import (
+    evaluate_betting_strategy,
+    implied_probability,
+    get_betting_context,
+)
 from .modeling import train_model
 from .wandb_train import train
 
@@ -7,6 +11,7 @@ __all__ = [
     "prepare_df",
     "evaluate_betting_strategy",
     "implied_probability",
+    "get_betting_context",
     "train_model",
     "train",
 ]

--- a/nfl_bet/betting.py
+++ b/nfl_bet/betting.py
@@ -116,6 +116,47 @@ def calculate_fixed_side_profits(
     return df
 
 
+def get_betting_context(orientation: str, bet_type: str) -> dict:
+    """Return target/odds columns and labels based on orientation and bet type."""
+    orientation = orientation.lower()
+    bet_type = bet_type.lower()
+    if orientation not in {"fav_dog", "home_away"}:
+        raise ValueError(f"Invalid orientation: {orientation}")
+    if bet_type not in {"moneyline", "spread"}:
+        raise ValueError(f"Invalid bet_type: {bet_type}")
+
+    if orientation == "fav_dog":
+        team1_label = "dog"
+        team2_label = "fav"
+        if bet_type == "moneyline":
+            target = "dog_win"
+            team1_odds_col = "dog_moneyline"
+            team2_odds_col = "fav_moneyline"
+        else:
+            target = "dog_cover"
+            team1_odds_col = "dog_spread_odds"
+            team2_odds_col = "fav_spread_odds"
+    else:
+        team1_label = "home"
+        team2_label = "away"
+        if bet_type == "moneyline":
+            target = "home_win"
+            team1_odds_col = "home_moneyline"
+            team2_odds_col = "away_moneyline"
+        else:
+            target = "home_cover"
+            team1_odds_col = "home_spread_odds"
+            team2_odds_col = "away_spread_odds"
+
+    return {
+        "target": target,
+        "team1_label": team1_label,
+        "team2_label": team2_label,
+        "team1_odds_col": team1_odds_col,
+        "team2_odds_col": team2_odds_col,
+    }
+
+
 def evaluate_betting_strategy(
     df: pd.DataFrame,
     model,


### PR DESCRIPTION
## Summary
- add a helper in `betting.py` to map orientation/bet type to target and odds
- expose the helper via the package
- allow `main.py` to specify `--orientation` and `--bet-type`
- incorporate orientation/bet type in wandb training
- extend evaluation utilities with the same options

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68432ebfc6f0832c808b168327b344c8