### PR TITLE
Implement regression handling for spread bets

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Execute the default workflow:
 ```bash
 python main.py
 ```
+Add ``--save-csv`` to also write the betting evaluation dataframe to
+``betting_results.csv`` for easy viewing in spreadsheet tools.
 
 ### W&B Training Utilities
 
@@ -105,6 +107,11 @@ For spread bets, ``get_betting_context()`` also returns ``line_col`` and
 ``regression_target``. These point to the appropriate spread column (e.g.,
 ``dog_line`` or ``home_line``) and the numeric margin target (``dog_margin`` or
 ``home_margin``).
+
+When ``--bet-type spread`` is selected the CLI tools automatically switch to a
+regression model. The network's last layer uses a linear activation and MSE loss
+while predictions represent the expected margin. Betting decisions compare this
+margin against the market line plus any supplied threshold.
 
 #### Training a home/away spread model
 

--- a/nfl_bet/modeling.py
+++ b/nfl_bet/modeling.py
@@ -2,7 +2,7 @@ from sklearn.model_selection import train_test_split
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import OneHotEncoder, StandardScaler
 from sklearn.pipeline import Pipeline
-from sklearn.linear_model import LogisticRegression
+from sklearn.linear_model import LogisticRegression, LinearRegression
 import pandas as pd
 
 
@@ -20,6 +20,7 @@ def train_model(
     target="dog_win",
     test_size=0.2,
     random_state=42,
+    model_type: str = "classification",
 ):
     if categorical_features is None:
         categorical_features = []
@@ -27,14 +28,22 @@ def train_model(
     preprocessor = build_preprocessor(numerical_features, categorical_features)
     X = df[features]
     y = df[target]
+    stratify = y if model_type == "classification" else None
     X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=test_size, stratify=y, random_state=random_state
+        X,
+        y,
+        test_size=test_size,
+        stratify=stratify,
+        random_state=random_state,
     )
     pipeline = Pipeline([
         ("preprocessor", preprocessor),
     ])
     X_train_trans = pipeline.fit_transform(X_train)
     X_test_trans = pipeline.transform(X_test)
-    model = LogisticRegression(max_iter=1000)
+    if model_type == "regression":
+        model = LinearRegression()
+    else:
+        model = LogisticRegression(max_iter=1000)
     model.fit(X_train_trans, y_train)
     return model, pipeline, (X_test_trans, y_test)

--- a/nfl_bet/wandb_eval.py
+++ b/nfl_bet/wandb_eval.py
@@ -141,6 +141,7 @@ def evaluate_betting_results(
 ) -> dict:
     """Return betting metrics for train/val/test and optional current year."""
     ctx = get_betting_context(orientation, bet_type)
+    model_type = "regression" if bet_type == "spread" else "classification"
     train_res = evaluate_betting_strategy(
         df=df_train,
         model=model,
@@ -153,6 +154,8 @@ def evaluate_betting_results(
         team2_label=ctx["team2_label"],
         team1_odds_col=ctx["team1_odds_col"],
         team2_odds_col=ctx["team2_odds_col"],
+        model_type=model_type,
+        line_col=ctx.get("line_col"),
     )
     train_metrics = {
         "train_profit": train_res["total_profit"],
@@ -173,6 +176,8 @@ def evaluate_betting_results(
         team2_label=ctx["team2_label"],
         team1_odds_col=ctx["team1_odds_col"],
         team2_odds_col=ctx["team2_odds_col"],
+        model_type=model_type,
+        line_col=ctx.get("line_col"),
     )
     val_metrics = {
         "val_profit": val_res["total_profit"],
@@ -193,6 +198,8 @@ def evaluate_betting_results(
         team2_label=ctx["team2_label"],
         team1_odds_col=ctx["team1_odds_col"],
         team2_odds_col=ctx["team2_odds_col"],
+        model_type=model_type,
+        line_col=ctx.get("line_col"),
     )
     test_metrics = {
         "test_profit": test_res["total_profit"],
@@ -215,6 +222,8 @@ def evaluate_betting_results(
             team2_label=ctx["team2_label"],
             team1_odds_col=ctx["team1_odds_col"],
             team2_odds_col=ctx["team2_odds_col"],
+            model_type=model_type,
+            line_col=ctx.get("line_col"),
         )
         cy_metrics = {
             "cy_profit": cy_res["total_profit"],
@@ -531,6 +540,7 @@ def evaluate_single_run(
     df_prepared = df_prepared[df_prepared["season"] < cy_year]
 
     target = ctx["target"]
+    model_type = "regression" if bet_type == "spread" else "classification"
     test_size = 0.1
     X_train_df, X_test_df, y_train_df, y_test_df = train_test_split(
         df_prepared[features],
@@ -563,6 +573,8 @@ def evaluate_single_run(
         team2_label=ctx["team2_label"],
         team1_odds_col=ctx["team1_odds_col"],
         team2_odds_col=ctx["team2_odds_col"],
+        model_type=model_type,
+        line_col=ctx.get("line_col"),
     )
     cy_res = evaluate_betting_strategy(
         df=cy_df,
@@ -576,6 +588,8 @@ def evaluate_single_run(
         team2_label=ctx["team2_label"],
         team1_odds_col=ctx["team1_odds_col"],
         team2_odds_col=ctx["team2_odds_col"],
+        model_type=model_type,
+        line_col=ctx.get("line_col"),
     )
     return test_res, cy_res
 


### PR DESCRIPTION
## Summary
- allow `train_model` to train classification or regression models
- add spread betting logic and helper
- switch CLI tools to use regression mode automatically for spread bets
- store `model_type` in W&B config
- save evaluation results with `--save-csv`
- document regression mode and CSV option in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68434146c560832ca33171c7f78b4509