### PR TITLE
Add results directory for CSV output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Quickly train a model and evaluate ROI. See
 |----------|---------|-------------|
 | `--orientation` | `fav_dog` | matchup framing |
 | `--bet-type` | `moneyline` | wager type |
-| `--save-csv` | `False` | write `betting_results.csv` |
+| `--save-csv` | `False` | write `results/betting_results_<orientation>_<bet-type>.csv` |
 
 Minimal example:
 
@@ -67,6 +67,7 @@ All parameters:
 ```bash
 python main.py --orientation home_away --bet-type spread --save-csv
 ```
+This writes `results/betting_results_home_away_spread.csv`.
 
 ### `python -m nfl_bet.wandb_train`
 

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import pandas as pd
 from nfl_bet import (
     prepare_df,
@@ -8,6 +9,7 @@ from nfl_bet import (
 )
 
 DATA_DIR = "data"
+RESULTS_DIR = "results"
 FIRST_YEAR = 2013
 CURRENT_YEAR = 2024
 
@@ -53,7 +55,10 @@ def main(argv: None | list[str] = None) -> None:
     parser.add_argument(
         "--save-csv",
         action="store_true",
-        help="Save detailed betting results to betting_results.csv",
+        help=(
+            "Save detailed betting results to "
+            "results/betting_results_<orientation>_<bet-type>.csv"
+        ),
     )
     args = parser.parse_args(argv)
 
@@ -105,7 +110,9 @@ def main(argv: None | list[str] = None) -> None:
     )
     df_results = results["df"]
     if args.save_csv:
-        df_results.to_csv("betting_results.csv", index=False)
+        os.makedirs(RESULTS_DIR, exist_ok=True)
+        out_path = f"{RESULTS_DIR}/betting_results_{args.orientation}_{args.bet_type}.csv"
+        df_results.to_csv(out_path, index=False)
     print("ROI: {:.2f}%".format(results["roi"]))
 
 


### PR DESCRIPTION
## Summary
- create `RESULTS_DIR` constant and use it for saving betting CSVs
- document new CSV file location in README
- ignore generated `results/` files

## Testing
- `python -m py_compile main.py`
- `python main.py --help | head -n 9`

------
https://chatgpt.com/codex/tasks/task_e_6845ddbfbbe0832c96ace8c78203088a