### PR TITLE
Adjust spread sign logic and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,13 @@ Depending on these choices, different target columns and odds are used. Implied 
 | orientation | bet_type | target | odds columns |
 |-------------|---------|--------|--------------|
 | `fav_dog`   | `moneyline` | `dog_win`   | `dog_moneyline` / `fav_moneyline` |
-| `fav_dog`   | `spread`    | `dog_cover` | `dog_spread_odds` / `fav_spread_odds` |
+| `fav_dog`   | `spread`    | `fav_cover` | `fav_spread_odds` / `dog_spread_odds` |
 | `home_away` | `moneyline` | `home_win`  | `home_moneyline` / `away_moneyline` |
 | `home_away` | `spread`    | `home_cover`| `home_spread_odds` / `away_spread_odds` |
 
 For spread bets, ``get_betting_context()`` also returns ``line_col`` and
 ``regression_target``. These point to the appropriate spread column (e.g.,
-``dog_line`` or ``home_line``) and the numeric margin target (``dog_margin`` or
+``fav_line`` or ``home_line``) and the numeric margin target (``fav_margin`` or
 ``home_margin``).
 
 When ``--bet-type spread`` is selected the CLI tools automatically switch to a

--- a/nfl_bet/betting.py
+++ b/nfl_bet/betting.py
@@ -171,18 +171,20 @@ def get_betting_context(orientation: str, bet_type: str) -> dict:
     regression_target = None
 
     if orientation == "fav_dog":
-        team1_label = "dog"
-        team2_label = "fav"
         if bet_type == "moneyline":
+            team1_label = "dog"
+            team2_label = "fav"
             target = "dog_win"
             team1_odds_col = "dog_moneyline"
             team2_odds_col = "fav_moneyline"
         else:
-            target = "dog_cover"
-            regression_target = "dog_margin"
-            line_col = "dog_line"
-            team1_odds_col = "dog_spread_odds"
-            team2_odds_col = "fav_spread_odds"
+            team1_label = "fav"
+            team2_label = "dog"
+            target = "fav_cover"
+            regression_target = "fav_margin"
+            line_col = "fav_line"
+            team1_odds_col = "fav_spread_odds"
+            team2_odds_col = "dog_spread_odds"
     else:
         team1_label = "home"
         team2_label = "away"

--- a/nfl_bet/data_prep.py
+++ b/nfl_bet/data_prep.py
@@ -190,8 +190,8 @@ def prepare_df(
     )
     df = add_h2h(df)
     df.dropna(inplace=True)
-    df["home_line"] = -df["spread_line"]
-    df["away_line"] = df["spread_line"]
+    df["home_line"] = df["spread_line"]
+    df["away_line"] = -df["spread_line"]
 
     if orientation == "fav_dog":
         # Determine favorite/underdog using the spread when available
@@ -225,9 +225,14 @@ def prepare_df(
         df["dog_win"] = df.apply(lambda row: 1 if row["dog_score"] > row["fav_score"] else 0, axis=1)
 
         if bet_type == "spread":
-            df["dog_margin"] = df["dog_score"] + df["dog_line"] - df["fav_score"]
+            df["dog_margin"] = df["dog_score"] - df["dog_line"] - df["fav_score"]
+            df["fav_margin"] = df["fav_score"] - df["fav_line"] - df["dog_score"]
             df["dog_cover"] = df.apply(
                 lambda row: 1 if row["dog_margin"] > 0 else 0,
+                axis=1,
+            )
+            df["fav_cover"] = df.apply(
+                lambda row: 1 if row["fav_margin"] > 0 else 0,
                 axis=1,
             )
             df["fav_implied_prob"] = df["fav_spread_odds"].apply(implied_probability)
@@ -269,7 +274,7 @@ def prepare_df(
     else:
         df["home_win"] = df["home_team_win"]
         if bet_type == "spread":
-            df["home_margin"] = df["home_score"] + df["home_line"] - df["away_score"]
+            df["home_margin"] = df["home_score"] - df["home_line"] - df["away_score"]
             df["home_cover"] = df.apply(
                 lambda row: 1 if row["home_margin"] > 0 else 0,
                 axis=1,


### PR DESCRIPTION
## Summary
- flip home and away line assignments
- recompute margins based on new sign convention
- make favourite spread the focus of training context
- update orientation table and descriptions

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684783ae99e4832c815d1b32010dfc0a