### PR TITLE
Add betting results filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,3 +168,15 @@ python -m nfl_bet.wandb_eval run \
     --orientation home_away \
     --bet-type spread
 ```
+
+### Filtering betting results
+
+`evaluate_betting_strategy()` returns a full DataFrame of per-game details in
+the `df` key. Use `filter_results_df()` to keep only the most relevant columns
+when writing CSVs:
+
+```python
+from nfl_bet.betting import filter_results_df
+trimmed = filter_results_df(results["df"], FEATURES, orientation, bet_type)
+trimmed.to_csv("results.csv", index=False)
+```

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from nfl_bet import (
     train_model,
     evaluate_betting_strategy,
     get_betting_context,
+    filter_results_df,
 )
 
 DATA_DIR = "data"
@@ -110,9 +111,15 @@ def main(argv: None | list[str] = None) -> None:
     )
     df_results = results["df"]
     if args.save_csv:
+        df_trimmed = filter_results_df(
+            df_results,
+            features,
+            args.orientation,
+            args.bet_type,
+        )
         os.makedirs(RESULTS_DIR, exist_ok=True)
         out_path = f"{RESULTS_DIR}/betting_results_{args.orientation}_{args.bet_type}.csv"
-        df_results.to_csv(out_path, index=False)
+        df_trimmed.to_csv(out_path, index=False)
     print("ROI: {:.2f}%".format(results["roi"]))
 
 

--- a/nfl_bet/__init__.py
+++ b/nfl_bet/__init__.py
@@ -3,6 +3,7 @@ from .betting import (
     evaluate_betting_strategy,
     implied_probability,
     get_betting_context,
+    filter_results_df,
 )
 from .modeling import train_model
 from .wandb_train import train
@@ -12,6 +13,7 @@ __all__ = [
     "evaluate_betting_strategy",
     "implied_probability",
     "get_betting_context",
+    "filter_results_df",
     "train_model",
     "train",
 ]


### PR DESCRIPTION
## Summary
- add `filter_results_df` helper for trimming evaluation output
- wire into `main.py` when writing CSV results
- expose helper from package
- document usage in README

## Testing
- `python -m py_compile main.py nfl_bet/betting.py nfl_bet/__init__.py`
- `find nfl_bet -name '*.py' -print | xargs python -m py_compile`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68478b86e78c832c96efe5801c75a32c