### PR TITLE
Fix class weights gating in train

### DIFF
--- a/nfl_bet/wandb_train.py
+++ b/nfl_bet/wandb_train.py
@@ -316,7 +316,7 @@ def train(config: Optional[dict] = None) -> None:
             lr_scheduler_cb = tf.keras.callbacks.LearningRateScheduler(scheduler)
             callbacks.append(lr_scheduler_cb)
 
-        if cfg.apply_class_weights:
+        if model_type == "classification" and cfg.apply_class_weights:
             class_weights = compute_class_weight(
                 class_weight="balanced", classes=np.unique(y_train), y=y_train
             )


### PR DESCRIPTION
## Summary
- apply class weight computation only for classification models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849bd3b536c832c86b25e53744f1bd8