### PR TITLE
Fix cy target selection in wandb_train

### DIFF
--- a/nfl_bet/wandb_train.py
+++ b/nfl_bet/wandb_train.py
@@ -346,7 +346,7 @@ def train(config: Optional[dict] = None) -> None:
         evaluate_and_log_metrics(model, X_test, y_test, "test", model_type)
 
         X_cy = cy_df[features]
-        y_cy = cy_df[ctx["target"]]
+        y_cy = cy_df[target_col]
         X_cy = pipeline.transform(X_cy)
         y_cy = y_cy.values
         evaluate_and_log_metrics(model, X_cy, y_cy, "cy", model_type)


### PR DESCRIPTION
## Summary
- align current year evaluation target with the training target column
- verify training run to ensure `cy_loss` behaves like other metrics

## Testing
- `WANDB_MODE=offline python -m nfl_bet.wandb_train example --project my_project | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6849c3010d44832c931bf54d1cfb323f