### PR TITLE
Adjust spread-mode defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,12 @@ Evaluate the top runs of a W&B project.
 | `--top-metric` | `loss` |
 | `--top-n` | `10` |
 | `--train-weight` | `1.0` |
-| `--metric-threshold` | `0.60` |
+| `--metric-threshold` | `0.60` (moneyline) / `175.0` (spread) |
 | `--exclude-tested` | `False` |
 | `--pull-high-roi` | `False` |
 | `--orientation` | `fav_dog` |
 | `--bet-type` | `moneyline` |
+When `--bet-type spread` is used, the evaluation checks default margins [0, 0.5, 1, 1.5, 2] and applies a higher default --metric-threshold (175.0) because regression losses are measured in points.
 
 Minimal example:
 


### PR DESCRIPTION
## Summary
- update `exe()` and `run_pipeline()` to set spread defaults for `margins`
- set metric-threshold dynamically and expose this via the CLI
- rely on function defaults in CLI rather than hardcoding values
- document spread-specific defaults in README

## Testing
- `python -m compileall -q nfl_bet`

------
https://chatgpt.com/codex/tasks/task_e_6849d6cabf40832c9eb72623711fef9c