### PR TITLE
Fix default bet strategies for home/away orientation

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ python -m nfl_bet.wandb_eval run --project nfl_bet_sweep_8 --top-metric loss --t
 The training and evaluation commands accept two important arguments:
 
 * `--orientation` selects which side of each matchup is modeled. Use `fav_dog` to frame games by favorite and underdog or `home_away` to model home and away teams directly.
+* When no strategies are specified, the defaults depend on the orientation: `["both", "dog", "fav"]` for `fav_dog` and `["both", "home", "away"]` for `home_away`.
 * `--bet-type` chooses whether the targets are based on straight wins (`moneyline`) or covering the spread (`spread`).
 
 Depending on these choices, different target columns and odds are used. Implied probabilities are derived with `calculate_implied_probabilities()` from the respective odds columns.

--- a/nfl_bet/wandb_eval.py
+++ b/nfl_bet/wandb_eval.py
@@ -255,7 +255,11 @@ def exe(
         raise RuntimeError("wandb is required for exe")
 
     if bet_strats is None:
-        bet_strats = ["both", "dog", "fav"]
+        bet_strats = (
+            ["both", "home", "away"]
+            if orientation == "home_away"
+            else ["both", "dog", "fav"]
+        )
     if margins is None:
         margins = [0, 0.5, 1, 1.5, 2] if bet_type == "spread" else [0.025, 0.05, 0.075, 0.1]
 
@@ -472,6 +476,13 @@ def run_pipeline(
         train_weight=train_weight,
         metric_threshold=metric_threshold,
     )
+    if bet_strats is None:
+        bet_strats = (
+            ["both", "home", "away"]
+            if orientation == "home_away"
+            else ["both", "dog", "fav"]
+        )
+
     results_df = exe(
         df_runs_epochs=top_runs_df,
         features=features,


### PR DESCRIPTION
## Summary
- make `exe()` choose bet strategies based on orientation
- do the same in `run_pipeline()` so CLI matches
- document the orientation-specific defaults

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849dcb4d540832c91751b3038b8e3bd