### PR TITLE
Add single run eval command

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,17 @@ python -m nfl_bet.wandb_eval run \
     --bet-type spread
 ```
 
+#### Saving predictions for a single run
+
+```bash
+python -m nfl_bet.wandb_eval single \
+    --project nfl_bet_sweep_8 \
+    --run-id <RUN_ID> \
+    --bet-strat both \
+    --margin 0.05
+```
+This writes `results/<RUN_ID>_test_preds.csv` and `results/<RUN_ID>_cy_preds.csv`.
+
 ### Filtering betting results
 
 `evaluate_betting_strategy()` returns a full DataFrame of per-game details in


### PR DESCRIPTION
## Summary
- add `single` subcommand to `wandb_eval.py` for saving predictions of a single run
- document how to run the new command

## Testing
- `pytest -q`
- `python -m nfl_bet.wandb_eval -h | head -n 20`
- `python -m nfl_bet.wandb_eval single -h | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6849dffb03e4832cb18478ead5c70abd