### PR TITLE
Refine wandb_eval CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,13 @@ python -m nfl_bet.wandb_train sweep --project nfl_bet_sweep --count 3 --orientat
 
 ### `python -m nfl_bet.wandb_eval`
 
-Evaluate the top runs of a W&B project.
+Utilities for evaluating W&B runs.
+
+**runs** subcommand
 
 | Argument | Default |
 |----------|---------|
-| `--project` | `nfl_bet_sweep_8` |
+| `--project` | required |
 | `--top-metric` | `loss` |
 | `--top-n` | `10` |
 | `--train-weight` | `1.0` |
@@ -126,18 +128,42 @@ Evaluate the top runs of a W&B project.
 | `--pull-high-roi` | `False` |
 | `--orientation` | `fav_dog` |
 | `--bet-type` | `moneyline` |
-When `--bet-type spread` is used, the evaluation checks default margins [0, 0.5, 1, 1.5, 2] and applies a higher default --metric-threshold (175.0) because regression losses are measured in points.
+When `--bet-type spread` is used, the evaluation checks default margins [0, 0.5, 1, 1.5, 2] and applies a higher default `--metric-threshold` (175.0) because regression losses are measured in points.
 
 Minimal example:
 
 ```bash
-python -m nfl_bet.wandb_eval run
+python -m nfl_bet.wandb_eval runs --project my_project
 ```
 
 All parameters:
 
 ```bash
-python -m nfl_bet.wandb_eval run --project nfl_bet_sweep_8 --top-metric loss --top-n 10 --train-weight 1.0 --metric-threshold 0.60 --exclude-tested --pull-high-roi --orientation home_away --bet-type spread
+python -m nfl_bet.wandb_eval runs --project nfl_bet_sweep_8 --top-metric loss --top-n 10 --train-weight 1.0 --metric-threshold 0.60 --exclude-tested --pull-high-roi --orientation home_away --bet-type spread
+```
+
+**single** subcommand
+
+| Argument | Default |
+|----------|---------|
+| `--project` | required |
+| `--run-id` | required |
+| `--bet-strat` | required |
+| `--margin` | required |
+| `--orientation` | `fav_dog` |
+| `--bet-type` | `moneyline` |
+| `--output` | `results` |
+
+Minimal example:
+
+```bash
+python -m nfl_bet.wandb_eval single --project my_project --run-id ABC123 --bet-strat both --margin 0.05
+```
+
+All parameters:
+
+```bash
+python -m nfl_bet.wandb_eval single --project my_project --run-id ABC123 --bet-strat fav --margin 1.0 --orientation home_away --bet-type spread --output custom_dir
 ```
 ### Orientation and Bet Type
 

--- a/nfl_bet/wandb_eval.py
+++ b/nfl_bet/wandb_eval.py
@@ -240,7 +240,7 @@ def evaluate_betting_results(
 def exe(
     df_runs_epochs: pd.DataFrame,
     features: List[str],
-    wandb_project: str = "nfl_bet_sweep_8",
+    wandb_project: str,
     bet_strats: Optional[List[str]] = None,
     margins: Optional[List[float]] = None,
     cy_df: Optional[pd.DataFrame] = None,
@@ -659,20 +659,20 @@ def aggregated_roi_table(df: pd.DataFrame) -> pd.DataFrame:
 def main(argv: Optional[List[str]] = None) -> None:
     parser = argparse.ArgumentParser(description="W&B evaluation utilities")
     sub = parser.add_subparsers(dest="command", required=True)
-    run_p = sub.add_parser("run", help="evaluate top runs and show ROI table")
-    run_p.add_argument("--project", default="nfl_bet_sweep_8", help="W&B project")
-    run_p.add_argument("--top-metric", default="loss", help="metric to rank runs")
-    run_p.add_argument("--top-n", type=int, default=10, help="number of runs")
-    run_p.add_argument("--train-weight", type=float, default=1.0)
-    run_p.add_argument("--metric-threshold", type=float)
-    run_p.add_argument("--exclude-tested", action="store_true")
-    run_p.add_argument("--pull-high-roi", action="store_true")
-    run_p.add_argument(
+    runs_p = sub.add_parser("runs", help="evaluate top runs and show ROI table")
+    runs_p.add_argument("--project", required=True, help="W&B project")
+    runs_p.add_argument("--top-metric", default="loss", help="metric to rank runs")
+    runs_p.add_argument("--top-n", type=int, default=10, help="number of runs")
+    runs_p.add_argument("--train-weight", type=float, default=1.0)
+    runs_p.add_argument("--metric-threshold", type=float)
+    runs_p.add_argument("--exclude-tested", action="store_true")
+    runs_p.add_argument("--pull-high-roi", action="store_true")
+    runs_p.add_argument(
         "--orientation",
         choices=["fav_dog", "home_away"],
         default="fav_dog",
     )
-    run_p.add_argument(
+    runs_p.add_argument(
         "--bet-type",
         choices=["moneyline", "spread"],
         default="moneyline",
@@ -705,7 +705,7 @@ def main(argv: Optional[List[str]] = None) -> None:
     )
 
     args = parser.parse_args(argv)
-    if args.command == "run":
+    if args.command == "runs":
         results = run_pipeline(
             wandb_project=args.project,
             features=DEFAULT_FEATURES,


### PR DESCRIPTION
## Summary
- rename the `run` subcommand to `runs`
- require `--project` for the `runs` parser
- remove default project from `exe`
- document the new CLI with examples for `runs` and `single`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849e851d2d8832cb917af9145b90f5f