### PR TITLE
Add sweep id option

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Utilities for running training jobs with optional W&B sweeps.
 |----------|---------|
 | `--project` | required |
 | `--count` | `50` |
+| `--sweep-id` | *(optional)* |
 | `--orientation` | required |
 | `--bet-type` | required |
 
@@ -105,10 +106,10 @@ Minimal example:
 python -m nfl_bet.wandb_train example --project my_project
 ```
 
-All parameters:
+All parameters (use `--sweep-id` to run an existing sweep):
 
 ```bash
-python -m nfl_bet.wandb_train sweep --project nfl_bet_sweep --count 3 --orientation home_away --bet-type spread
+python -m nfl_bet.wandb_train sweep --project nfl_bet_sweep --count 3 --sweep-id ABC123 --orientation home_away --bet-type spread
 ```
 
 ### `python -m nfl_bet.wandb_eval`

--- a/nfl_bet/wandb_train.py
+++ b/nfl_bet/wandb_train.py
@@ -558,6 +558,10 @@ def main(argv: Optional[list[str]] = None) -> None:
         help="Number of sweep runs to execute",
     )
     sweep_parser.add_argument(
+        "--sweep-id",
+        help="Existing sweep ID to run. If omitted a new sweep is created",
+    )
+    sweep_parser.add_argument(
         "--orientation",
         choices=["fav_dog", "home_away"],
         default="fav_dog",
@@ -578,8 +582,14 @@ def main(argv: Optional[list[str]] = None) -> None:
             bet_type=args.bet_type,
         )
     elif args.command == "sweep":
-        sid = create_sweep(
-            project=args.project, orientation=args.orientation, bet_type=args.bet_type
+        sid = (
+            args.sweep_id
+            if args.sweep_id
+            else create_sweep(
+                project=args.project,
+                orientation=args.orientation,
+                bet_type=args.bet_type,
+            )
         )
         run_sweep(sid, count=args.count)
 


### PR DESCRIPTION
## Summary
- add `--sweep-id` option to use an existing W&B sweep in `wandb_train`
- document new option in README

## Testing
- `python -m py_compile nfl_bet/wandb_train.py`

------
https://chatgpt.com/codex/tasks/task_e_684c2dfad380832ca59c7e89890fb63e