### PR TITLE
Update sweep runner to forward project

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ Utilities for running training jobs with optional W&B sweeps.
 | `--orientation` | required |
 | `--bet-type` | required |
 
+When using `--sweep-id` to resume an existing sweep, pass the original
+`--project` so the agent logs to the correct W&B project.
+
 Minimal example:
 
 ```bash

--- a/nfl_bet/wandb_train.py
+++ b/nfl_bet/wandb_train.py
@@ -461,13 +461,38 @@ def create_sweep(
     return sweep_id
 
 
-def run_sweep(sweep_id: str, *, count: int = 50) -> None:
-    """Launch a W&B sweep agent."""
+def run_sweep(
+    sweep_id: str,
+    *,
+    count: int = 50,
+    project: str | None = None,
+    entity: str | None = None,
+) -> None:
+    """Launch a W&B sweep agent.
+
+    Parameters
+    ----------
+    sweep_id : str
+        Identifier of the sweep to run.
+    count : int, optional
+        Number of runs to execute. Defaults to ``50``.
+    project : str, optional
+        W&B project name. Must match the project used to create the sweep when
+        running an existing sweep.
+    entity : str, optional
+        W&B entity (username or organization).
+    """
 
     if wandb is None:
         raise ImportError("wandb must be installed to run sweeps")
 
-    wandb.agent(sweep_id=sweep_id, function=train, count=count)
+    wandb.agent(
+        sweep_id=sweep_id,
+        function=train,
+        count=count,
+        project=project,
+        entity=entity,
+    )
 
 # ---------------------------------------------------------------------------
 # Example entry point
@@ -591,7 +616,10 @@ def main(argv: Optional[list[str]] = None) -> None:
                 bet_type=args.bet_type,
             )
         )
-        run_sweep(sid, count=args.count)
+        if args.sweep_id:
+            run_sweep(sid, count=args.count, project=args.project)
+        else:
+            run_sweep(sid, count=args.count)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- extend `run_sweep` so sweep agents can specify the WandB project
- pass project when invoking a sweep via CLI if using `--sweep-id`
- document project requirement for resumed sweeps in README

## Testing
- `pytest -q`
- `python -m py_compile nfl_bet/wandb_train.py`


------
https://chatgpt.com/codex/tasks/task_e_684c3402ee24832c81f837dc1101ec75