### PR TITLE
Use point differentials for spread regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,10 +188,10 @@ Depending on these choices, different target columns and odds are used. Implied 
 
 For spread bets, ``get_betting_context()`` also returns ``line_col`` and
 ``regression_target``. These point to the appropriate spread column (e.g.,
-``fav_line`` or ``home_line``) and the numeric margin target (``fav_margin`` or
-``home_margin``).
+``fav_line`` or ``home_line``) and the numeric point-difference target
+(``fav_diff`` or ``home_diff``).
 
 When ``--bet-type spread`` is selected the CLI tools automatically switch to a
 regression model. The network's last layer uses a linear activation and MSE loss
-while predictions represent the expected margin. Betting decisions compare this
-margin against the market line plus any supplied margin.
+while predictions represent the expected point difference. Betting decisions
+compare this difference against the market line plus any supplied margin.

--- a/nfl_bet/betting.py
+++ b/nfl_bet/betting.py
@@ -62,7 +62,7 @@ def determine_spread_bet_team(
     team1_label: str = "dog",
     team2_label: str = "fav",
 ) -> str:
-    """Return which side to bet based on predicted margin vs. the spread.
+    """Return which side to bet based on predicted point difference vs. the spread.
 
     Parameters
     ----------
@@ -77,6 +77,11 @@ def determine_spread_bet_team(
         Label for the team when betting on the side predicted to cover.
     team2_label : str, optional
         Label for the opposite team.
+
+    Notes
+    -----
+    ``predictions`` are expected to represent the point difference
+    between ``team1`` and ``team2`` from ``team1``'s perspective.
     """
     predicted = row["predictions"]
     line = row[line_col]
@@ -203,7 +208,7 @@ def get_betting_context(orientation: str, bet_type: str) -> dict:
             team1_label = "fav"
             team2_label = "dog"
             target = "fav_cover"
-            regression_target = "fav_margin"
+            regression_target = "fav_diff"
             line_col = "fav_line"
             team1_odds_col = "fav_spread_odds"
             team2_odds_col = "dog_spread_odds"
@@ -216,7 +221,7 @@ def get_betting_context(orientation: str, bet_type: str) -> dict:
             team2_odds_col = "away_moneyline"
         else:
             target = "home_cover"
-            regression_target = "home_margin"
+            regression_target = "home_diff"
             line_col = "home_line"
             team1_odds_col = "home_spread_odds"
             team2_odds_col = "away_spread_odds"
@@ -340,7 +345,9 @@ def evaluate_betting_strategy(
     }
 
 
-def filter_results_df(df: pd.DataFrame, features: list[str], orientation: str, bet_type: str) -> pd.DataFrame:
+def filter_results_df(
+    df: pd.DataFrame, features: list[str], orientation: str, bet_type: str
+) -> pd.DataFrame:
     """Return a trimmed version of the betting results DataFrame.
 
     Parameters


### PR DESCRIPTION
## Summary
- add fav_diff/home_diff columns and keep margin columns
- use diff columns as regression targets in `get_betting_context`
- clarify spread betting docstring
- document new diff columns and predicted point difference in README

## Testing
- `python -m py_compile nfl_bet/data_prep.py nfl_bet/betting.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_684c52609410832cb36d68a37e6e8f61