### PR TITLE
Centralize feature constants

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from nfl_bet import (
     get_betting_context,
     filter_results_df,
 )
+from nfl_bet.constants import DEFAULT_FEATURES
 
 DATA_DIR = "data"
 RESULTS_DIR = "results"
@@ -63,17 +64,7 @@ def run_once(
         orientation=orientation,
         bet_type=bet_type,
     )
-    features = [
-        "rushing_offense_adv",
-        "passing_offense_adv",
-        "rushing_defense_adv",
-        "passing_defense_adv",
-        "win_percentage_diff",
-        "implied_prob_diff",
-        "rest_advantage",
-        "div_game",
-        "h2h_type",
-    ]
+    features = DEFAULT_FEATURES
     context = get_betting_context(orientation, bet_type)
     cat_features = ["h2h_type", "div_game"]
     target_col = (

--- a/nfl_bet/__init__.py
+++ b/nfl_bet/__init__.py
@@ -7,6 +7,7 @@ from .betting import (
 )
 from .modeling import train_model
 from .wandb_train import train
+from .constants import DEFAULT_FEATURES
 
 __all__ = [
     "prepare_df",
@@ -16,6 +17,7 @@ __all__ = [
     "filter_results_df",
     "train_model",
     "train",
+    "DEFAULT_FEATURES",
 ]
 from .wandb_eval import (
     run_pipeline,

--- a/nfl_bet/constants.py
+++ b/nfl_bet/constants.py
@@ -1,0 +1,11 @@
+DEFAULT_FEATURES = [
+    "rushing_offense_adv",
+    "passing_offense_adv",
+    "rushing_defense_adv",
+    "passing_defense_adv",
+    "win_percentage_diff",
+    "implied_prob_diff",
+    "rest_advantage",
+    "div_game",
+    "h2h_type",
+]

--- a/nfl_bet/wandb_eval.py
+++ b/nfl_bet/wandb_eval.py
@@ -15,6 +15,7 @@ from joblib import load
 from . import evaluate_betting_strategy, prepare_df, get_betting_context
 from .wandb_train import load_data, CURRENT_YEAR
 from .betting import filter_results_df
+from .constants import DEFAULT_FEATURES
 
 RESULTS_DIR = "results"
 
@@ -620,17 +621,6 @@ def evaluate_single_run(
 # ---------------------------------------------------------------------------
 # CLI helpers
 # ---------------------------------------------------------------------------
-DEFAULT_FEATURES = [
-    "rushing_offense_adv",
-    "passing_offense_adv",
-    "rushing_defense_adv",
-    "passing_defense_adv",
-    "win_percentage_diff",
-    "implied_prob_diff",
-    "rest_advantage",
-    "div_game",
-    "h2h_type",
-]
 
 
 def filter_eval_results(

--- a/nfl_bet/wandb_train.py
+++ b/nfl_bet/wandb_train.py
@@ -20,6 +20,7 @@ from sklearn.utils.class_weight import compute_class_weight
 
 from .data_prep import prepare_df
 from .betting import evaluate_betting_strategy, get_betting_context
+from .constants import DEFAULT_FEATURES
 
 try:
     import wandb
@@ -66,17 +67,7 @@ def load_data():
 # Modeling helpers
 # ---------------------------------------------------------------------------
 
-features = [
-    "rushing_offense_adv",
-    "passing_offense_adv",
-    "rushing_defense_adv",
-    "passing_defense_adv",
-    "win_percentage_diff",
-    # "implied_prob_diff",
-    "rest_advantage",
-    "div_game",
-    "h2h_type",
-]
+features = DEFAULT_FEATURES
 
 categorical_features = ["h2h_type"]
 binary_features = ["div_game"]


### PR DESCRIPTION
## Summary
- add `nfl_bet/constants.py` defining `DEFAULT_FEATURES`
- import and use the new constant throughout the package

## Testing
- `python -m py_compile main.py nfl_bet/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684c5c2e8c7c832c80bc9d634d53ccc1