### PR TITLE
Add dataset export option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Quickly train a model and evaluate ROI. See
 | `--orientation` | `fav_dog` | matchup framing |
 | `--bet-type` | `moneyline` | wager type |
 | `--save-csv` | `False` | write `results/betting_results_<orientation>_<bet-type>.csv` |
+| `--save-dataset` | `False` | write `results/training_data_<orientation>_<bet-type>.csv` |
 | `--margin` | `0.0` | minimum edge required to place a bet |
 | `--run-all` | `False` | run every orientation and bet type combo |
 
@@ -67,16 +68,18 @@ python main.py
 All parameters:
 
 ```bash
-python main.py --orientation home_away --bet-type spread --margin 0.05 --save-csv
+python main.py --orientation home_away --bet-type spread --margin 0.05 --save-csv --save-dataset
 ```
-This writes `results/betting_results_home_away_spread.csv`.
+This writes `results/betting_results_home_away_spread.csv` and
+`results/training_data_home_away_spread.csv`.
 
 Running all combinations:
 
 ```bash
 python main.py --run-all
 ```
-This writes four CSVs for every orientation and bet type pair.
+This writes four betting results files and four training datasets,
+one for each orientation/bet type combination.
 
 ### `python -m nfl_bet.wandb_train`
 

--- a/main.py
+++ b/main.py
@@ -51,6 +51,7 @@ def run_once(
     schedules: pd.DataFrame,
     margin: float = 0.0,
     save_csv: bool = False,
+    save_dataset: bool = False,
 ) -> None:
     """Train and evaluate a single orientation/bet type combination."""
     model_type = "regression" if bet_type == "spread" else "classification"
@@ -70,6 +71,14 @@ def run_once(
     target_col = (
         context["regression_target"] if model_type == "regression" else context["target"]
     )
+
+    if save_dataset:
+        os.makedirs(RESULTS_DIR, exist_ok=True)
+        df_dataset = df[features + [target_col]].copy()
+        if target_col != "target":
+            df_dataset = df_dataset.rename(columns={target_col: "target"})
+        out_dataset = f"{RESULTS_DIR}/training_data_{orientation}_{bet_type}.csv"
+        df_dataset.to_csv(out_dataset, index=False)
     model, pipeline, (X_test, y_test) = train_model(
         df,
         features,
@@ -127,6 +136,14 @@ def main(argv: None | list[str] = None) -> None:
         ),
     )
     parser.add_argument(
+        "--save-dataset",
+        action="store_true",
+        help=(
+            "Save training data (features + target) to "
+            "results/training_data_<orientation>_<bet-type>.csv"
+        ),
+    )
+    parser.add_argument(
         "--run-all",
         action="store_true",
         help="Run all orientation/bet-type combinations sequentially",
@@ -157,6 +174,7 @@ def main(argv: None | list[str] = None) -> None:
                 schedules=schedules,
                 margin=args.margin,
                 save_csv=True,
+                save_dataset=args.save_dataset,
             )
     else:
         run_once(
@@ -168,6 +186,7 @@ def main(argv: None | list[str] = None) -> None:
             schedules=schedules,
             margin=args.margin,
             save_csv=args.save_csv,
+            save_dataset=args.save_dataset,
         )
 
 


### PR DESCRIPTION
## Summary
- save training features + target as CSV
- document the new `--save-dataset` flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dc42d2910832cb49debeb018b5a6c